### PR TITLE
[haagjn] CPack exercise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(yaml-cpp
   )
 
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "filesystem/filesystem.hpp;fem/fem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
 
 add_executable("${PROJECT_NAME}" main.cpp)
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
@@ -26,3 +27,15 @@ target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+include(GNUInstallDirs)
+install(TARGETS "${PROJECT_NAME}" cpackexamplelib
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/  
+  )
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(MyPackagingModule)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:20.04
+
+# Set timezone
+ENV TZ=Europe/Berlin
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Install packages
+RUN apt update -y
+RUN apt install -y libboost-all-dev cmake build-essential libdeal.ii-dev git vim libyaml-cpp-dev
+
+# Copy folder to the container
+ADD . /cpack-exercise
+
+# Create build folder and run cmake
+RUN cd cpack-exercise && mkdir build && cd build && cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release ..
+# Run cpack to create packages
+#RUN cpack -G DEB && cpack -G TGZ
+# Install the Debian package
+#RUN apt install ./cpackexample_0.2.0_amd64.deb
+# Copy the packages to the mounted directory
+#RUN cp cpackexample_0.2.0_amd64.deb ../../mnt/package-build-dir/ && cp cpackexample-0.2.0-Linux.tar.gz ../../mnt/package-build-dir/
+
+CMD ["/bin/bash"]

--- a/cmake/MyPackagingModule.cmake
+++ b/cmake/MyPackagingModule.cmake
@@ -1,0 +1,18 @@
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE CPack exercise" CACHE STRING "This is a simple package created as part of the SSE lecture at the University of Stuttgart in the winter term 21/22. Its main objective is to get familiar with CPack.")
+set(CPACK_PACKAGE_VENDOR "Jonathan Haag")
+set(CPACK_PACKAGE_CONTACT "Jonathan Haag <st157676@stud.uni-stuttgart.de>")
+set(CPACK_PACKAGE_MAINTAINER "Jonathan Haag")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://simulation-software-engineering.github.io/homepage/")
+set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+set(CPACK_STRIP_FILES TRUE)
+set(CPACK_GENERATOR "TGZ;DEB")
+
+#Debian specific changes
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+SET(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+
+include(CPack)


### PR DESCRIPTION
I opened this as a draft PR since I have some weird issue with my Dockerfile:
```
RUN cpack -G DEB && cpack -G TGZ
```
results in the following error:
```
CPack Error: CPack project name not specified
```
However, running everything up until this point, entering the running container, stepping into the build directory and running the cpack-command works just fine / produces the expected result. I also tried running `make package` in the Dockerfile, which does not work (`No rule to make target package`). Right now, one can still get everything going following the recipe below which does lead to the packages being copied to the mounted directory aka your host pwd. I also left the commands in the Dockerfile that should normally produce the same result but commented them out. If they were to work, one would just need to run the `docker build && docker run` command below.

Any suggestions as to what I can do to fix this or what might be the issue on my machine? Thanks in advance! 😄 

----------------

To build and run the container please use:
```console
docker build -t cpack-exercise-image . && docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/package-build-dir cpack-exercise-image
```

Inside the container run the following command to build the packages and copy them to the mounted directory such that they appear in the current working directory on your host machine:
```console
cd cpack-exercise/build
cpack -G DEB && cpack -G TGZ
cp cpackexample_0.2.0_amd64.deb ../../mnt/package-build-dir/ && cp cpackexample-0.2.0-Linux.tar.gz ../../mnt/package-build-dir/
```

You can also install the package and test the installation via:
```console
apt install ./cpackexample_0.2.0_amd64.deb
cd ..
cpackexample yamlParser/config.yml
```

